### PR TITLE
chore: release v0.1.0

### DIFF
--- a/centaurus-derive/CHANGELOG.md
+++ b/centaurus-derive/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/Profiidev/centaurus/releases/tag/centaurus-derive-v0.1.0) - 2025-09-28
+
+### Added
+
+- initial commit

--- a/centaurus/CHANGELOG.md
+++ b/centaurus/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/Profiidev/centaurus/releases/tag/centaurus-v0.1.0) - 2025-09-28
+
+### Added
+
+- added request utils
+- added init code
+- initial commit
+
+### Other
+
+- added pipelines
+- added missing features


### PR DESCRIPTION



## 🤖 New release

* `centaurus-derive`: 0.1.0
* `centaurus`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `centaurus-derive`

<blockquote>

## [0.1.0](https://github.com/Profiidev/centaurus/releases/tag/centaurus-derive-v0.1.0) - 2025-09-28

### Added

- initial commit
</blockquote>

## `centaurus`

<blockquote>

## [0.1.0](https://github.com/Profiidev/centaurus/releases/tag/centaurus-v0.1.0) - 2025-09-28

### Added

- added request utils
- added init code
- initial commit

### Other

- added pipelines
- added missing features
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).