### PR TITLE
chore: release v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "98e529aee37b5c8206bb4bf4c44797127566d72f76952c970bd3d1e85de8f4e2"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -195,8 +195,7 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -212,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "f9bcffc1a1d0c6a74823b55df1f1c829c0d49e884518c021cc4d93471f772b1f"
 dependencies = [
  "bytes",
  "futures-core",
@@ -232,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+checksum = "d86d701cd16f401888ebe9c3214dc838c7ef27a405d5726196765a913603b5dd"
 dependencies = [
  "axum",
  "axum-core",
@@ -248,10 +247,10 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "serde",
- "tower",
+ "serde_core",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2744,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -2898,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Centaurus
 
 Library with utilities I use in various of my projects.
+
+- [Centaurus](./centaurus) - The utils
+- [Centaurus Derive](./centaurus-derive) - The derive macros for [Centaurus](https://github.com/Profiidev/centaurus)
+
+## Documentation
+
+The documentation is available at [docs.rs](https://docs.rs/centaurus).

--- a/centaurus-derive/README.md
+++ b/centaurus-derive/README.md
@@ -1,0 +1,3 @@
+# Centaurus Derive
+
+The derive macros for [Centaurus](https://github.com/Profiidev/centaurus)

--- a/centaurus/README.md
+++ b/centaurus/README.md
@@ -1,0 +1,3 @@
+# Centaurus
+
+The utils


### PR DESCRIPTION



## 🤖 New release

* `centaurus-derive`: 0.1.0
* `centaurus`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `centaurus-derive`

<blockquote>

## [0.1.0](https://github.com/Profiidev/centaurus/releases/tag/centaurus-derive-v0.1.0) - 2025-09-28

### Added

- initial commit
</blockquote>

## `centaurus`

<blockquote>

## [0.1.0](https://github.com/Profiidev/centaurus/releases/tag/centaurus-v0.1.0) - 2025-09-28

### Added

- added request utils
- added init code
- initial commit

### Other

- added pipelines
- added missing features
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).