### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "centaurus"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "addr",
  "aide",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "centaurus-derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "centaurus-macro-utils",
  "quote",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "centaurus-macro-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "syn 2.0.117",
  "toml_edit",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "3"
 members = ["centaurus", "centaurus-derive", "centaurus-macro-utils"]
 
 [workspace.dependencies]
-centaurus-derive = { path = "./centaurus-derive", version = "0.1.2" }
-centaurus-macro-utils = { path = "./centaurus-macro-utils", version = "0.1.0" }
+centaurus-derive = { path = "./centaurus-derive", version = "0.1.3" }
+centaurus-macro-utils = { path = "./centaurus-macro-utils", version = "0.1.1" }

--- a/centaurus-derive/CHANGELOG.md
+++ b/centaurus-derive/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-04-24
+
+### 🐛 Bug Fixes
+
+- Update message derive
+
+### 🚜 Refactor
+
+- Deps order
+
+
+
 ## [0.1.2] - 2026-04-05
 
 ### 🚀 Features

--- a/centaurus-derive/Cargo.toml
+++ b/centaurus-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centaurus-derive"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A utility library for various use cases."
 readme = "README.md"

--- a/centaurus-macro-utils/CHANGELOG.md
+++ b/centaurus-macro-utils/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2026-04-24
+
+### 🚀 Features
+
+- Added option to pass custom crate name in macro utils
+
+### 🚜 Refactor
+
+- Deps order
+
+
+
 ## [0.1.0] - 2026-04-05
 
 ### 🚀 Features

--- a/centaurus-macro-utils/Cargo.toml
+++ b/centaurus-macro-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centaurus-macro-utils"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Macro utilities for the centaurus"
 readme = "README.md"

--- a/centaurus/CHANGELOG.md
+++ b/centaurus/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-04-24
+
+### 🚀 Features
+
+- Added http3 feature
+
+### 🐛 Bug Fixes
+
+- Image feature flags
+- File names
+- Update message derive
+
+### 🚜 Refactor
+
+- Migration numbering
+- Db feature flags
+- Backend req + middleware
+- Endpoints
+- Auth feature flags
+- Deps order
+- Use error report
+
+### ⚙️ Miscellaneous Tasks
+
+- Fix code style issues with clippy
+- Added feature test
+- Fix code style issues with rustfmt
+
+
+
 ## [0.9.1] - 2026-04-09
 
 ### 🐛 Bug Fixes

--- a/centaurus/Cargo.toml
+++ b/centaurus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "centaurus"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 description = "A utility library for various use cases."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `centaurus-macro-utils`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `centaurus-derive`: 0.1.2 -> 0.1.3
* `centaurus`: 0.9.1 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `centaurus` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum centaurus::db::migrations::setup::Setup, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/setup.rs:30
  enum centaurus::db::migrations::key::Key, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/key.rs:30
  enum centaurus::db::migrations::groups::GroupUser, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/groups.rs:156
  enum centaurus::db::migrations::user::User, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/user.rs:51
  enum centaurus::db::migrations::groups::GroupPermission, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/groups.rs:163
  enum centaurus::db::migrations::settings::Settings, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/settings.rs:29
  enum centaurus::db::migrations::invalid_jwt::InvalidJwt, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/invalid_jwt.rs:30
  enum centaurus::req::xml::XmlRejection, previously in file /tmp/.tmp75kJze/centaurus/src/req/xml.rs:28
  enum centaurus::db::migrations::groups::Group, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/groups.rs:149

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_missing.ron

Failed in:
  feature all in the package's Cargo.toml
  feature axum in the package's Cargo.toml
  feature lettre in the package's Cargo.toml
  feature sea-orm in the package's Cargo.toml
  feature rand in the package's Cargo.toml

--- failure feature_no_longer_enables_feature: package feature no longer enables another feature ---

Description:
A feature no longer enables another feature in this package's Cargo.toml. This will break downstream crates which rely on the implied feature being enabled.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove-another
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_no_longer_enables_feature.ron

Failed in:
  feature auth no longer enables error
  feature auth no longer enables serde
  feature auth no longer enables url
  feature gravatar no longer enables base64
  feature gravatar no longer enables reqwest

--- failure feature_not_enabled_by_default: package feature is not enabled by default ---

Description:
A feature is no longer enabled by default for this package. This will break downstream crates which rely on the package's default features and require the functionality of this feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove-another
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_not_enabled_by_default.ron

Failed in:
  feature serde_xml in the package's Cargo.toml
  feature proxy in the package's Cargo.toml
  feature metrics in the package's Cargo.toml
  feature frontend in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function centaurus::backend::group::list_users_simple_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/group.rs:48
  function centaurus::backend::user::management::create_user_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:45
  function centaurus::backend::user::management::user_info_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:57
  function centaurus::backend::user::account::update_avatar_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/account.rs:31
  function centaurus::backend::user::management::reset_user_avatar_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:69
  function centaurus::backend::mail::template::test_email, previously in file /tmp/.tmp75kJze/centaurus/src/backend/mail/template.rs:34
  function centaurus::backend::mail::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/mail/mod.rs:15
  function centaurus::backend::settings::get_user_settings_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/settings.rs:25
  function centaurus::backend::settings::save_mail_settings_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/settings.rs:37
  function centaurus::backend::setup::is_setup_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/setup.rs:30
  function centaurus::backend::websocket::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/websocket/mod.rs:11
  function centaurus::backend::user::info::info_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/info.rs:17
  function centaurus::backend::user::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/mod.rs:9
  function centaurus::backend::group::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/group.rs:17
  function centaurus::backend::group::create_group_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/group.rs:32
  function centaurus::backend::group::group_info_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/group.rs:44
  function centaurus::backend::user::management::list_users_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:41
  function centaurus::backend::user::management::edit_user_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:53
  function centaurus::backend::user::account::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/account.rs:23
  function centaurus::backend::user::management::list_groups_simple_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:65
  function centaurus::backend::user::account::update_account_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/account.rs:39
  function centaurus::backend::mail::template::reset_link, previously in file /tmp/.tmp75kJze/centaurus/src/backend/mail/template.rs:1
  function centaurus::backend::settings::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/settings.rs:17
  function centaurus::backend::settings::get_mail_settings_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/settings.rs:33
  function centaurus::backend::setup::complete_setup_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/setup.rs:26
  function centaurus::req::health::router, previously in file /tmp/.tmp75kJze/centaurus/src/req/health.rs:3
  function centaurus::backend::user::info::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/info.rs:13
  function centaurus::backend::group::list_groups_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/group.rs:28
  function centaurus::backend::group::edit_group_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/group.rs:40
  function centaurus::backend::user::management::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:28
  function centaurus::backend::user::management::delete_user_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:49
  function centaurus::backend::user::management::mail_active_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:61
  function centaurus::backend::user::account::update_password_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/account.rs:35
  function centaurus::backend::user::management::reset_user_password_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:73
  function centaurus::backend::mail::state, previously in file /tmp/.tmp75kJze/centaurus/src/backend/mail/mod.rs:22
  function centaurus::backend::settings::save_user_settings_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/settings.rs:29
  function centaurus::backend::setup::router, previously in file /tmp/.tmp75kJze/centaurus/src/backend/setup.rs:20
  function centaurus::backend::setup::create_admin_group, previously in file /tmp/.tmp75kJze/centaurus/src/backend/setup.rs:34
  function centaurus::backend::websocket::state, previously in file /tmp/.tmp75kJze/centaurus/src/backend/websocket/mod.rs:15
  function centaurus::backend::user::template::init_password, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/template.rs:1
  function centaurus::backend::group::delete_group_route, previously in file /tmp/.tmp75kJze/centaurus/src/backend/group.rs:36

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod centaurus::backend::group, previously in file /tmp/.tmp75kJze/centaurus/src/backend/group.rs:1
  mod centaurus::backend::user::management, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/management.rs:1
  mod centaurus::db::migrations::setup, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/setup.rs:1
  mod centaurus::backend::setup, previously in file /tmp/.tmp75kJze/centaurus/src/backend/setup.rs:1
  mod centaurus::req::xml, previously in file /tmp/.tmp75kJze/centaurus/src/req/xml.rs:1
  mod centaurus::db::migrations::key, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/key.rs:1
  mod centaurus::req::redirect, previously in file /tmp/.tmp75kJze/centaurus/src/req/redirect.rs:1
  mod centaurus::state::extract, previously in file /tmp/.tmp75kJze/centaurus/src/state/extract.rs:1
  mod centaurus::db::migrations::settings, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/settings.rs:1
  mod centaurus::db::migrations::groups, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/groups.rs:1
  mod centaurus::db::migrations::invalid_jwt, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/invalid_jwt.rs:1
  mod centaurus::backend::settings, previously in file /tmp/.tmp75kJze/centaurus/src/backend/settings.rs:1
  mod centaurus::backend::websocket, previously in file /tmp/.tmp75kJze/centaurus/src/backend/websocket/mod.rs:1
  mod centaurus::backend::user::template, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/template.rs:1
  mod centaurus::backend::user::info, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/info.rs:1
  mod centaurus::backend::mail, previously in file /tmp/.tmp75kJze/centaurus/src/backend/mail/mod.rs:1
  mod centaurus::backend::websocket::state, previously in file /tmp/.tmp75kJze/centaurus/src/backend/websocket/state.rs:1
  mod centaurus::backend::mail::state, previously in file /tmp/.tmp75kJze/centaurus/src/backend/mail/state.rs:1
  mod centaurus::backend::res, previously in file /tmp/.tmp75kJze/centaurus/src/backend/res.rs:1
  mod centaurus::backend::user::account, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/account.rs:1
  mod centaurus::backend::mail::template, previously in file /tmp/.tmp75kJze/centaurus/src/backend/mail/template.rs:1
  mod centaurus::db::migrations::user, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/user.rs:1
  mod centaurus::req::header, previously in file /tmp/.tmp75kJze/centaurus/src/req/header.rs:1
  mod centaurus::req, previously in file /tmp/.tmp75kJze/centaurus/src/req/mod.rs:1
  mod centaurus::req::health, previously in file /tmp/.tmp75kJze/centaurus/src/req/health.rs:1
  mod centaurus::backend::user, previously in file /tmp/.tmp75kJze/centaurus/src/backend/user/mod.rs:1
  mod centaurus::state, previously in file /tmp/.tmp75kJze/centaurus/src/state/mod.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct centaurus::db::migrations::setup::Migration, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/setup.rs:4
  struct centaurus::db::migrations::groups::Migration, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/groups.rs:6
  struct centaurus::backend::websocket::state::UpdateTrigger, previously in file /tmp/.tmp75kJze/centaurus/src/backend/websocket/state.rs:64
  struct centaurus::db::migrations::key::Migration, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/key.rs:4
  struct centaurus::db::migrations::invalid_jwt::Migration, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/invalid_jwt.rs:4
  struct centaurus::req::xml::Xml, previously in file /tmp/.tmp75kJze/centaurus/src/req/xml.rs:11
  struct centaurus::req::redirect::Redirect, previously in file /tmp/.tmp75kJze/centaurus/src/req/redirect.rs:5
  struct centaurus::backend::mail::state::ResetPasswordState, previously in file /tmp/.tmp75kJze/centaurus/src/backend/mail/state.rs:14
  struct centaurus::backend::websocket::state::UpdateState, previously in file /tmp/.tmp75kJze/centaurus/src/backend/websocket/state.rs:26
  struct centaurus::db::migrations::user::Migration, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/user.rs:4
  struct centaurus::backend::res::TokenRes, previously in file /tmp/.tmp75kJze/centaurus/src/backend/res.rs:13
  struct centaurus::backend::websocket::state::Updater, previously in file /tmp/.tmp75kJze/centaurus/src/backend/websocket/state.rs:48
  struct centaurus::db::migrations::settings::Migration, previously in file /tmp/.tmp75kJze/centaurus/src/db/migrations/settings.rs:4

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_missing.ron

Failed in:
  trait centaurus::state::extract::StateExtractExt, previously in file /tmp/.tmp75kJze/centaurus/src/state/extract.rs:5
  trait centaurus::backend::websocket::state::UpdateMessage, previously in file /tmp/.tmp75kJze/centaurus/src/backend/websocket/state.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `centaurus-macro-utils`

<blockquote>

## [0.1.1] - 2026-04-24

### 🚀 Features

- Added option to pass custom crate name in macro utils

### 🚜 Refactor

- Deps order
</blockquote>

## `centaurus-derive`

<blockquote>

## [0.1.3] - 2026-04-24

### 🐛 Bug Fixes

- Update message derive

### 🚜 Refactor

- Deps order
</blockquote>

## `centaurus`

<blockquote>

## [0.10.0] - 2026-04-24

### 🚀 Features

- Added http3 feature

### 🐛 Bug Fixes

- Image feature flags
- File names
- Update message derive

### 🚜 Refactor

- Migration numbering
- Db feature flags
- Backend req + middleware
- Endpoints
- Auth feature flags
- Deps order
- Use error report

### ⚙️ Miscellaneous Tasks

- Fix code style issues with clippy
- Added feature test
- Fix code style issues with rustfmt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).